### PR TITLE
Replicate MultiDodgesRemaining

### DIFF
--- a/classes/UTComp_xPawn.uc
+++ b/classes/UTComp_xPawn.uc
@@ -33,6 +33,9 @@ var UTComp_HUDSettings HUDSettings;
 
 replication
 {
+  reliable if (Role==ROLE_Authority)
+     MultiDodgesRemaining;
+
   unreliable if (Role==Role_authority)
      bShieldActive, bLinkActive, bShockActive, bLGactive, overlayActive;
 }
@@ -1072,5 +1075,5 @@ defaultproperties
      lgcolor=(B=80,G=40,R=40)
      beffectscleared=True
 
-     MultiDodgesRemaining=1
+     MultiDodgesRemaining=0
 }


### PR DESCRIPTION
The server initializes this value in `MutUTComp::ModifyPlayer()` based off the config, however the client never receives that update and is locked to the default in `UTComp_xPawn`. This replicates the property to respect the `MaxMultiDodges` value.