### PR TITLE
fix for vehicles causing degradation and crash

### DIFF
--- a/classes/MutUTComp.uc
+++ b/classes/MutUTComp.uc
@@ -461,10 +461,45 @@ function ModifyPlayer(Pawn Other)
 
 function DriverEnteredVehicle(Vehicle V, Pawn P)
 {
-	SpawnCollisionCopy(V);
+    local PawnCollisionCopy C;
+    if(RepInfo != none && RepInfo.bEnableEnhancedNetCode)
+    {
+        C = PCC;
+        while(C != None)
+        {
+            if(C.CopiedPawn == P)
+            {
+                C.SetPawn(V);
+                break;
+            }
+            C = C.Next;
+        }
+    }
 
     if( NextMutator != none )
 		NextMutator.DriverEnteredVehicle(V, P);
+}
+
+function DriverLeftVehicle(Vehicle V, Pawn P)
+{
+    local PawnCollisionCopy C;
+
+    if(RepInfo != None && RepInfo.bEnableEnhancedNetCode)
+    {
+        C = PCC;
+        while(C != None)
+        {
+            if(C.CopiedPawn == V)
+            {
+                C.SetPawn(P);
+                break;
+            }
+            C = C.Next;
+        }
+    }
+
+    if( NextMutator != none )
+		NextMutator.DriverLeftVehicle(V, P);
 }
 
 function SpawnCollisionCopy(Pawn Other)

--- a/classes/PawnCollisionCopy.uc
+++ b/classes/PawnCollisionCopy.uc
@@ -64,10 +64,12 @@ function SetPawn(Pawn Other)
     bCrouched=CopiedPawn.bIsCrouched;
 
     //If we cant use simple collisions, set up the mesh
-    if(!bUseCylinderCollision)
-        LinkMesh(CopiedPawn.Mesh);
-    else
-        SetCollisionSize(CopiedPawn.CollisionRadius, CopiedPawn.CollisionHeight);
+    //if(!bUseCylinderCollision)
+    //    LinkMesh(CopiedPawn.Mesh);
+    //else
+    // Linking the mesh causes a slow memory leak and eventual crash
+    // it works fine without linking mesh 
+    SetCollisionSize(CopiedPawn.CollisionRadius, CopiedPawn.CollisionHeight);
 }
 
 /*


### PR DESCRIPTION
We've been running a modified version of UTComp on our Onslaught server for a few years now.  In the first few weeks of using it we ran into an issue where the server would slowly degrade over time and eventually crash.  Clients frames per second would also drop from 200fps down to 30-50fps over the course of 5 minutes or so.  

It was determined to be due to two issues:

1) PawnCollisionCopy was spawned every time a vehicle was entered, but it was never destroyed, so every vehicle entry resulted in a memory leak.  
2) When SetPawn() is called in PawnCollisionCopy, it calls LinkMesh for pawns with mesh based collision like vehicles.  After 3 years of testing, there has been no issues with removing the call to LinkMesh.  Enhanced netcode still works fine on vehicles without linking the mesh.

The fix is
1) Re-use the entry pawn's collision copy for the vehicle when entering, and replace it when leaving.  
2) don't use LinkMesh.  It's not needed.


