### PR TITLE
fix issue with netcode breaking in second round in ONS and AS gametypes

### DIFF
--- a/classes/BS_xPlayer.uc
+++ b/classes/BS_xPlayer.uc
@@ -143,6 +143,9 @@ replication
         ReceiveWeaponEffect;
     reliable if (bDemoRecording)
         DemoReceiveWeaponEffect;
+
+    reliable if(Role == ROLE_Authority)
+        ClientResetNetcode;        
 }
 
 simulated function SaveSettings()
@@ -3781,6 +3784,17 @@ simulated final function SendWeaponEffect(
         HitNormal * 32767,
         ReflectNum
     );
+}
+
+simulated function ClientResetNetcode()
+{
+    local Timestamp_Pawn P;
+
+    foreach DynamicActors(class'Timestamp_Pawn', P)
+    {
+        if(P != None)
+            P.Destroy();
+    }
 }
 
 defaultproperties

--- a/classes/MutUTComp.uc
+++ b/classes/MutUTComp.uc
@@ -1399,6 +1399,26 @@ function string GetInventoryClassOverride(string InventoryClassName)
 	return InventoryClassName;
 }
 
+function Reset()
+{
+    local Controller C;
+
+    // remove all Timestamp_pawn from clients
+    for(C = Level.ControllerList;C != None;C = C.NextController)
+    {
+        if(BS_xPlayer(C) != None)
+            BS_xPlayer(C).ClientResetNetcode();
+    }
+
+    // delete these server side, the get recreated in SetPawnStamp function
+    counterpawn.Unpossessed();
+    counterpawn.Destroy();
+    counterpawn = none;
+    countercontroller.Pawn = None;
+    countercontroller.Destroy();
+    countercontroller = None;
+}
+
 defaultproperties
 {
      bAddToServerPackages=True

--- a/classes/TimeStamp_Pawn.uc
+++ b/classes/TimeStamp_Pawn.uc
@@ -50,4 +50,5 @@ DefaultProperties
     bBlockPlayers=false
     bDisturbFluidSurface=false
     Physics=Phys_None
+    bstasis=false
 }


### PR DESCRIPTION
In Assault and Onslaught game modes, during the second round transition the game types call RoundHasEnded() for all controllers.  This includes the Timestamp_Controller.  This causes the netcode to break in second round.  The RoundHasEnded() calls Pawn.Unpossessed() and the controller Destroy()s itself.  This results in the Timestamp_Pawn running on the client to become detached and Tick() stops happening.  When that happens the Timestamp is no longer updated and the NewNet weapons cannot find the correct collision copy due to bad timestamp.

For whatever reason (engine bug in native ControllerList?) RoundHasEnded() cannot be overridden in Timestamp_Controller.  The overridden function is never called.  The base method is always called.  So to fix this we:

1. Add a function on clients 'ClientResetNetcode' which deletes the existing Timestamp_Pawn.
2. Add a Reset() function to MutUTComp which is called when resetting the level without restarting.  This function calls ClientResetNetcode for all clients, and then deletes the server side Timestamp_Pawn and Timestamp_Controller.
3. Finally, we add bstasis=false flag to Timestamp_Pawn so that tick() still gets called when the new timestamp_pawn gets replicated.  This does not seem to be needed for the bNetInitial replication of Timestamp_Pawn, but subsequent replications do need it or Tick is not called on clients.  